### PR TITLE
docs: remove unnecessary line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Sharppad
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)  
-[![Build Status](https://img.shields.io/github/workflow/status/coretravis/sharppad/CI)](https://github.com/coretravis/sharppad/actions)  
 [![GitHub stars](https://img.shields.io/github/stars/coretravis/sharppad)](https://github.com/coretravis/sharppad/stargazers)
 
 Sharppad is an open-source, browser-based interactive development environment for writing, executing, embedding, and sharing C# code.


### PR DESCRIPTION
### Description

This pull request removes an unnecessary line from the README file. The change cleans up the documentation to improve clarity and readability.

### Rationale

- **Clarity:** The removed line was redundant and could cause confusion.
- **Maintenance:** Keeping the documentation concise helps maintain it over time.

### Changes

- Removed the extraneous line from the README.

### Verification

- Reviewed the rendered README on GitHub to ensure the layout remains correct.
- Confirmed that no other documentation content was affected.