### PR TITLE
chore: add workflow_dispatch trigger to deploy-docs.yml

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
### Description

This pull request updates the `deploy-docs.yml` workflow file by adding the `workflow_dispatch` trigger. This addition allows for manual execution of the documentation deployment process to GitHub Pages.

### Changes Made

- Added `workflow_dispatch:` to the event triggers in `.github/workflows/deploy-docs.yml`.

### Rationale

- **Manual Trigger:** The new trigger enables a "Run workflow" button in the Actions tab, providing flexibility to manually deploy the documentation when needed.
- **Testing & Flexibility:** It simplifies testing and ensures deployments can be initiated on demand rather than solely on pushes to the `main` branch.

### Testing/Verification

- Confirmed that the updated workflow file resides in the `.github/workflows` directory.
- Verified the appearance of the "Run workflow" button in the Actions tab.
- Manually triggered the workflow to ensure that the deployment process runs as expected.