### PR TITLE
bugfix: pass UserLoggedIn parameter to ScriptLibrary component

### DIFF
--- a/src/Client/CodeBox/Pad.razor
+++ b/src/Client/CodeBox/Pad.razor
@@ -43,7 +43,7 @@
                Size="Modal.ModalSize.FullScreen"
                Position="Modal.ModalPosition.Top"
                IsOpenChanged="@(value => isScriptLibraryOpen = value)">
-            <ScriptLibrary ScriptSelected="LoadLibraryScript" />
+            <ScriptLibrary ScriptSelected="LoadLibraryScript" UserLoggedIn="@isLoggedIn" />
         </Modal>
 
         <aside class="side-panel @(isPanelOpen ? "open" : "")">


### PR DESCRIPTION
**Description:**  
This pull request fixes an issue in the Script Library component where user scripts were not displayed even when a user was logged in. The problem was traced to the missing `UserLoggedIn` parameter. The fix involves updating the modal component to pass the `@isLoggedIn` value to the ScriptLibrary component.

**Changes Made:**

- Updated the modal code to include the `UserLoggedIn="@isLoggedIn"` parameter:
  ```razor
  <ScriptLibrary ScriptSelected="LoadLibraryScript" UserLoggedIn="@isLoggedIn" />
  ```
- Verified that the user scripts are now correctly displayed when the user is logged in.

**Verification:**

- Tested the component with a logged-in user to ensure the scripts display as expected.
- Confirmed that no side effects were introduced in other areas of the component.